### PR TITLE
fix: add account-map bypass pattern support for static account mapping

### DIFF
--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,3 +1,15 @@
+variable "account_map_enabled" {
+  type        = bool
+  description = "Set to true to use the account-map component for account lookups. Set to false to use the static account_map variable."
+  default     = true
+}
+
+variable "account_map" {
+  type        = any
+  description = "Account map to use when account_map_enabled is false. Expected to contain at least 'full_account_map' with account name to ID mappings."
+  default     = {}
+}
+
 provider "aws" {
   region = var.region
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -24,11 +24,14 @@ module "account_map" {
   version = "1.8.0"
 
   component   = var.account_map_component_name
-  environment = var.account_map_environment_name
-  stage       = var.account_map_stage_name
-  tenant      = coalesce(var.account_map_tenant_name, module.this.tenant)
+  tenant      = var.account_map_enabled ? coalesce(var.account_map_tenant_name, module.this.tenant) : null
+  environment = var.account_map_enabled ? var.account_map_environment_name : null
+  stage       = var.account_map_enabled ? var.account_map_stage_name : null
 
   context = module.this.context
+
+  bypass   = !var.account_map_enabled
+  defaults = var.account_map
 }
 
 module "vpc" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -72,3 +72,15 @@ variable "account_map_component_name" {
   description = "The name of the account-map component"
   default     = "account-map"
 }
+
+variable "account_map_enabled" {
+  type        = bool
+  description = "Set to true to use the account-map component for account lookups. Set to false to use the static account_map variable."
+  default     = true
+}
+
+variable "account_map" {
+  type        = any
+  description = "Account map to use when account_map_enabled is false. Expected to contain at least 'full_account_map' with account name to ID mappings."
+  default     = {}
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -72,15 +72,3 @@ variable "account_map_component_name" {
   description = "The name of the account-map component"
   default     = "account-map"
 }
-
-variable "account_map_enabled" {
-  type        = bool
-  description = "Set to true to use the account-map component for account lookups. Set to false to use the static account_map variable."
-  default     = true
-}
-
-variable "account_map" {
-  type        = any
-  description = "Account map to use when account_map_enabled is false. Expected to contain at least 'full_account_map' with account name to ID mappings."
-  default     = {}
-}


### PR DESCRIPTION
## What

Add support for the account-map bypass pattern in `remote-state.tf`, allowing this component to work with static account mapping instead of requiring the `account-map` component.

### Changes

- Added `account_map_enabled` and `account_map` variables to `providers.tf`
- Updated `module.account_map` in `remote-state.tf` to use the bypass pattern when `account_map_enabled = false`

## Why

When using the `provider-without-account-map.tf` mixin (common in refarch-scaffold deployments), users need to provide a static account map instead of deploying the `account-map` component. The upstream `remote-state.tf` previously didn't support this pattern, causing deployments to fail with errors like:

```
Error: Could not find the component 'account-map' in the stack 'core-gbl-root'
```

With this change:
- **Default behavior unchanged**: `account_map_enabled = true` by default, so existing users are unaffected
- **Static mapping supported**: When `account_map_enabled = false`, the component uses the `bypass` and `defaults` parameters to skip the remote state lookup

## References

- [Remote State Bypass Pattern](https://atmos.tools/core-concepts/components/remote-state#extracting-outputs-from-remote-state-using-static-remote-state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration controls to enable or disable account mapping functionality.
  * Introduced support for default account mapping configurations.
  * Implemented conditional parameter handling for account mapping with bypass mode support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->