### PR TITLE
feat: expose amazon_side_asn variable

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -8,7 +8,7 @@
 
 module "tgw_hub" {
   source  = "cloudposse/transit-gateway/aws"
-  version = "0.13.0"
+  version = "0.13.1"
 
   amazon_side_asn            = var.amazon_side_asn
   ram_resource_share_enabled = var.ram_resource_share_enabled

--- a/src/main.tf
+++ b/src/main.tf
@@ -10,6 +10,7 @@ module "tgw_hub" {
   source  = "cloudposse/transit-gateway/aws"
   version = "0.13.0"
 
+  amazon_side_asn            = var.amazon_side_asn
   ram_resource_share_enabled = var.ram_resource_share_enabled
   ram_principals             = var.ram_principals
   allow_external_principals  = var.allow_external_principals

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -26,6 +26,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "../../account-map/modules/iam-roles"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=v1.537.2"
   context = module.this.context
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -21,7 +21,7 @@ locals {
 
 module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.account_map_component_name
   tenant      = var.account_map_enabled ? coalesce(var.account_map_tenant_name, module.this.tenant) : null
@@ -40,7 +40,7 @@ module "vpc" {
   => c }
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = each.value.component
   stage       = each.value.stage
@@ -62,7 +62,7 @@ module "eks" {
   => c }
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = each.value.component
   stage       = each.value.stage

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -72,3 +72,16 @@ variable "account_map_component_name" {
   description = "The name of the account-map component"
   default     = "account-map"
 }
+
+variable "amazon_side_asn" {
+  type        = number
+  default     = 64512
+  description = <<-EOT
+    Private Autonomous System Number (ASN) for the Amazon side of a BGP session.
+    The range is `64512` to `65534` for 16-bit ASNs and `4200000000` to `4294967294` for 32-bit ASNs.
+
+    Distinct ASNs are required across hubs when peering Transit Gateways, associating with
+    a Direct Connect Gateway, or running BGP Site-to-Site VPN against the same on-premises router.
+    Changing this value forces replacement of the Transit Gateway.
+  EOT
+}


### PR DESCRIPTION
## what

Surfaces the new `amazon_side_asn` variable from `cloudposse/terraform-aws-transit-gateway` and passes it through to the underlying module.

```diff
 module "tgw_hub" {
   source  = "cloudposse/transit-gateway/aws"
   version = "0.13.0"

+  amazon_side_asn            = var.amazon_side_asn
   ram_resource_share_enabled = var.ram_resource_share_enabled
   ...
 }
```

```hcl
variable "amazon_side_asn" {
  type    = number
  default = 64512
}
```

## why

This component currently does not allow operators to set a non-default ASN on the Transit Gateway, so every hub created with it gets ASN `64512`. This breaks down for any landing zone that runs more than one TGW (per environment, per region, etc.) and later needs to:

- peer two TGWs (same or cross-region) — AWS rejects the peering attachment when both sides share an ASN
- associate one or more TGWs with a Direct Connect Gateway — each TGW associated with a DXGW must have a unique ASN
- terminate BGP-based Site-to-Site VPN against the same on-premises customer gateway from multiple TGWs

Because \`amazon_side_asn\` is \`ForceNew\` on the underlying \`aws_ec2_transit_gateway\` resource, retrofitting it later destroys the TGW and every VPC attachment / RAM share / route table along with it. Exposing the variable now lets operators set it correctly on day one.

## depends on

This change requires the upstream module PR:

- https://github.com/cloudposse/terraform-aws-transit-gateway/pull/67 (\`feat: expose amazon_side_asn variable\`)

Once that PR is merged and released, the \`version\` pin in \`src/main.tf\` will need to be bumped from \`0.13.0\` to the new release (likely \`0.14.0\`). Happy to push that bump as a follow-up commit on this PR as soon as the module release lands.

## references

- AWS Terraform provider — [\`aws_ec2_transit_gateway\` argument reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway#amazon_side_asn)
- AWS API — [\`TransitGatewayRequestOptions.AmazonSideAsn\`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TransitGatewayRequestOptions.html)
- AWS whitepaper — [Building a Scalable and Secure Multi-VPC AWS Network Infrastructure](https://docs.aws.amazon.com/whitepapers/latest/building-scalable-secure-multi-vpc-network-infrastructure/welcome.html)

## test

- \`terraform fmt -recursive\` — clean
- Default value preserves current behavior; no existing stack will see drift.
- Full \`terraform validate\` requires the component's mixin resolution (account-map etc.) which CP CI provides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Amazon-side ASN for Transit Gateway (default: 64512).

* **Chores**
  * Bumped Transit Gateway module to a newer patch release.
  * Switched IAM-roles module to a pinned upstream provider source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse-terraform-components/aws-tgw-hub/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->